### PR TITLE
README: update FantomasCLI package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You can also use Fantomas extension in Ivan's [fsharp-vs-commands](https://githu
 
 ### Command line tool / API 
 You can fork this repo and compile the project with F# 3.0/.NET framework 4.0. 
-Alternatively, Fantomas is also available via [a NuGet package](https://nuget.org/packages/Fantomas/) which contains both the library and the command line interface.
+Alternatively, Fantomas is also available via [a NuGet package](https://www.nuget.org/packages/FantomasCLI/) which contains both the library and the command line interface.
 For detailed guidelines, please read [Fantomas: How to use](docs/Documentation.md#using-the-command-line-tool).
 
 ### FAKE build system


### PR DESCRIPTION
Because only that package contains both the executable and the library.