### PR TITLE
Add enum identifiers in strict mode (#186)

### DIFF
--- a/src/Fantomas.Tests/StringTests.fs
+++ b/src/Fantomas.Tests/StringTests.fs
@@ -68,6 +68,26 @@ let g = '\n'
 """
 
 [<Test>]
+let ``uncommon literals strict mode``() =
+    formatSourceString false """
+let a = 0xFFy
+let c = 0b0111101us
+let d = 0o0777
+let e = 1.40e10f
+let f = 23.4M
+let g = '\n'
+    """ { config with StrictMode=true }
+    |> prepend newline
+    |> should equal """
+let a = -1y
+let c = 61us
+let d = 511
+let e = 1.4e+10f
+let f = 23.4M
+let g = '\010'
+"""
+
+[<Test>]
 let ``should preserve triple-quote strings``() =
     formatSourceString false "
     type GetList() =

--- a/src/Fantomas.Tests/UnionTests.fs
+++ b/src/Fantomas.Tests/UnionTests.fs
@@ -136,3 +136,22 @@ let main argv =
     | Test (A = a; B = b) -> a + b
     | _ -> 0
 """
+
+[<Test>]
+let ``enums conversion with strict mode``() =
+    formatSourceString false """
+type uColor =
+   | Red = 0u
+   | Green = 1u
+   | Blue = 2u
+let col3 = Microsoft.FSharp.Core.LanguagePrimitives.EnumOfValue<uint32, uColor>(2u)""" { config with StrictMode = true }
+    |> prepend newline
+    |> should equal """
+type uColor =
+    | Red = 0u
+    | Green = 1u
+    | Blue = 2u
+
+let col3 =
+    Microsoft.FSharp.Core.LanguagePrimitives.EnumOfValue<uint32, uColor>(2u)
+"""

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -835,10 +835,11 @@ and genUnionCase astContext (UnionCase(ats, px, _, s, UnionCaseType fs)) =
     +> genOnelinerAttributes astContext ats -- s 
     +> colPre wordOf sepStar fs (genField { astContext with IsUnionField = true } "")
 
-and genEnumCase astContext (EnumCase(ats, px, _, c)) =
+and genEnumCase astContext (EnumCase(ats, px, s, c)) =
     genPreXmlDoc px 
     +> ifElse astContext.HasVerticalBar sepBar sepNone 
-    +> genOnelinerAttributes astContext ats +> genConst c
+    +> genOnelinerAttributes astContext ats 
+    +> (fun ctx -> (if ctx.Config.StrictMode then !- s -- " = " else !- "") ctx) +> genConst c
 
 and genField astContext prefix (Field(ats, px, ao, isStatic, isMutable, t, so)) = 
     // Being protective on union case declaration

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -106,8 +106,11 @@ let hasParenInPat = function
 let genConst (Unresolved(c, r, s)) =
     let r' = c.Range r
     fun ctx -> 
-        let s' = defaultArg (lookup r' ctx) s
-        str s' ctx
+        if ctx.Config.StrictMode then
+            str s ctx
+        else
+            let s' = defaultArg (lookup r' ctx) s
+            str s' ctx
 
 /// Check whether a range starting with a specified token
 let startWith prefix (r : range) ctx = 

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -106,11 +106,8 @@ let hasParenInPat = function
 let genConst (Unresolved(c, r, s)) =
     let r' = c.Range r
     fun ctx -> 
-        if ctx.Config.StrictMode then
-            str s ctx
-        else
-            let s' = defaultArg (lookup r' ctx) s
-            str s' ctx
+        let s' = defaultArg (lookup r' ctx) s
+        str s' ctx
 
 /// Check whether a range starting with a specified token
 let startWith prefix (r : range) ctx = 


### PR DESCRIPTION
Fixed #186 by adding `Case =` part in strict mode.

Also added test for uncommon literals in strict mode.