### PR TITLE
 Print single subtype constraint without "when". (Fix #126)

### DIFF
--- a/src/Fantomas.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Tests/FunctionDefinitionTests.fs
@@ -111,6 +111,15 @@ let divide x y =
 """
 
 [<Test>]
+let ``simple subtype constraint``() =
+    formatSourceString false """
+let subtype (xs : seq<'t :> System.IDisposable>) = ()""" config
+    |> prepend newline
+    |> should equal """
+let subtype (xs : seq<'t :> System.IDisposable>) = ()
+"""
+
+[<Test>]
 let ``type constraints and inline``() =
     formatSourceString false """
 let inline add(value1 : ^T when ^T : (static member (+) : ^T * ^T -> ^T), value2: ^T) =

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -876,6 +876,7 @@ and genType astContext outerBracket t =
 
         | TLongIdentApp(t, s, ts) -> loop t -- sprintf ".%s" s +> genPrefixTypes astContext ts
         | TTuple ts -> sepOpenT +> loopTTupleList ts +> sepCloseT
+        | TWithGlobalConstraints(TVar _, [TyparSubtypeOfType _ as tc]) -> genTypeConstraint astContext tc
         | TWithGlobalConstraints(TFuns ts, tcs) -> col sepArrow ts loop +> colPre (!- " when ") wordAnd tcs (genTypeConstraint astContext)        
         | TWithGlobalConstraints(t, tcs) -> loop t +> colPre (!- " when ") wordAnd tcs (genTypeConstraint astContext)
         | TLongIdent s -> !- s


### PR DESCRIPTION
Fix case: 
`let subtype (xs : seq<'t :> System.IDisposable>) = ()` 
-> 
`let subtype (xs : seq<'t when 't :> System.IDisposable>) = ()`, 
root cause of #126.