### PR TITLE
 Use lookup for return type in extern definition. (Fix #189).

### DIFF
--- a/src/Fantomas.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Tests/FunctionDefinitionTests.fs
@@ -214,6 +214,18 @@ module InteropWithNative =
 """
 
 [<Test>]
+let ``should handle external functions with void return type``() =
+    formatSourceString false """module InteropWithNative =
+        [<DllImport(@"__Internal", CallingConvention = CallingConvention.Cdecl)>]
+        extern void setCallbridgeSupportTarget(IntPtr newTarget)""" config
+    |> prepend newline
+    |> should equal """
+module InteropWithNative =
+    [<DllImport(@"__Internal", CallingConvention = CallingConvention.Cdecl)>]
+    extern void setCallbridgeSupportTarget(IntPtr newTarget)
+"""
+
+[<Test>]
 let ``should handle external functions with fully-qualified attributes``() =
     formatSourceString false """[<System.Runtime.InteropServices.DllImport("user32.dll")>]
 extern int GetWindowLong(System.IntPtr hwnd, int index)""" config

--- a/src/Fantomas/SourceTransformer.fs
+++ b/src/Fantomas/SourceTransformer.fs
@@ -103,14 +103,18 @@ let hasParenInPat = function
     | PatParen _ -> true
     | _ -> false
 
-let genConst (Unresolved(c, r, s)) =
-    let r' = c.Range r
+let getByLookup range f x =
     fun ctx -> 
         if ctx.Config.StrictMode then
-            str s ctx
+            f x ctx
         else
-            let s' = defaultArg (lookup r' ctx) s
-            str s' ctx
+            match lookup range ctx with
+            | Some x' ->
+                str x' ctx
+            | None ->
+                f x ctx
+
+let genConst (Unresolved(c, r, s)) = getByLookup (c.Range r) str s
 
 /// Check whether a range starting with a specified token
 let startWith prefix (r : range) ctx = 


### PR DESCRIPTION
Fix #189.

+ some DRY refactoring around lookup functions.