### PR TITLE
Fix type annotation in members with getter/setter (fix #225), fix space-at-end-of-line issues in members.

### DIFF
--- a/src/Fantomas.Tests/ClassTests.fs
+++ b/src/Fantomas.Tests/ClassTests.fs
@@ -101,11 +101,11 @@ type Shape2D(x0 : float, y0 : float) =
     let mutable x, y = x0, y0
     let mutable rotAngle = 0.0
     
-    member this.CenterX 
+    member this.CenterX
         with get () = x
         and set xval = x <- xval
     
-    member this.CenterY 
+    member this.CenterY
         with get () = y
         and set yval = y <- yval
     
@@ -281,4 +281,18 @@ let ``should work on static auto properties``() =
 """  config
     |> should equal """type A() =
     static member val LastSchema = "" with get, set
+"""
+
+[<Test>]
+let ``member properties with type annotation``() =
+    formatSourceString false """type A() =
+    member this.X with get():int = 1
+    member this.Y with get():int = 1 and set (_:int):unit = ()
+"""  config
+    |> should equal """type A() =
+    member this.X : int = 1
+    
+    member this.Y
+        with get () : int = 1
+        and set (_ : int) : unit = ()
 """

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -147,7 +147,7 @@ type public MyClass<'a> public (x, y) as this =
     static member StaticMethod a = a + 1
     member internal self.Prop1 = x
     
-    member self.Prop2 
+    member self.Prop2
         with get () = z
         and set (a) = z <- a
     
@@ -257,7 +257,7 @@ type Derived1() =
     inherit AbstractBase()
     let mutable value = 10
     
-    override this.Property1 
+    override this.Property1
         with get () = value
         and set (v : int) = value <- v
 """
@@ -276,19 +276,19 @@ type Foo() =
     |> should equal """
 type Foo() =
     member x.Get = 1
-    member x.Set 
+    member x.Set
         with private set (v : int) = value <- v
     
-    member x.GetSet 
+    member x.GetSet
         with internal get () = value
         and private set (v : bool) = value <- v
     
-    member x.GetI 
+    member x.GetI
         with internal get (key1, key2) = false
-    member x.SetI 
+    member x.SetI
         with private set (key1, key2) value = ()
     
-    member x.GetSetI 
+    member x.GetSetI
         with internal get (key1, key2) = true
         and private set (key1, key2) value = ()
 """
@@ -361,15 +361,15 @@ type NumberStrings() =
     let mutable ordinals = [| "one" |]
     let mutable cardinals = [| "first" |]
     
-    member this.Item 
+    member this.Item
         with get index = ordinals.[index]
         and set index value = ordinals.[index] <- value
     
-    member this.Ordinal 
+    member this.Ordinal
         with get (index) = ordinals.[index]
         and set index value = ordinals.[index] <- value
     
-    member this.Cardinal 
+    member this.Cardinal
         with get (index) = cardinals.[index]
         and set index value = cardinals.[index] <- value
 """
@@ -395,7 +395,7 @@ open System.Collections.Generic
 type SparseMatrix() =
     let mutable table = new Dictionary<int * int, float>()
     
-    member this.Item 
+    member this.Item
         with get (key1, key2) = table.[(key1, key2)]
         and set (key1, key2) value = table.[(key1, key2)] <- value
 
@@ -500,11 +500,11 @@ type Person(nameIn : string, idIn : int) =
     let mutable id = idIn
     do printfn "Created a person object."
     
-    member this.Name 
+    member this.Name
         with get () = name
         and set (v) = name <- v
     
-    member this.ID 
+    member this.ID
         with get () = id
         and set (v) = id <- v
     
@@ -663,7 +663,7 @@ type A() =
     |> prepend newline
     |> should equal """
 type A() =
-    override this.Address 
+    override this.Address
         with set v =
             let x =
                 match _kbytes.GetAddress(8) with
@@ -681,7 +681,7 @@ type A() =
     |> prepend newline
     |> should equal """
 type A() =
-    member x.B 
+    member x.B
         with set v =
             "[<System.Runtime.InteropServices.DllImport(\"user32.dll\")>] extern int GetWindowLong(System.IntPtr hwnd, int index)" 
             |> ignore
@@ -706,13 +706,13 @@ type Bar =
     |> should equal """
 type Bar =
     
-    member this.Item 
+    member this.Item
         with get (i : int) =
             match mo with
             | Some(m) when m.Groups.[i].Success -> m.Groups.[i].Value
             | _ -> null
     
-    member this.Item 
+    member this.Item
         with get (i : string) =
             match mo with
             | Some(m) when m.Groups.[i].Success -> m.Groups.[i].Value

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -262,6 +262,12 @@ and preserveBreakNln astContext e ctx =
 and preserveBreakNlnOrAddSpace astContext e ctx =
     breakNlnOrAddSpace astContext (checkPreserveBreakForExpr e ctx) e ctx
 
+and genExprSepEqPrependType astContext prefix e =
+    match e with
+    | TypedExpr(Typed, e, t) -> prefix +> sepColon +> genType astContext false t +> sepEq
+                                +> preserveBreakNlnOrAddSpace astContext e
+    | e -> prefix +> sepEq +> preserveBreakNlnOrAddSpace astContext e
+
 /// Break but doesn't indent the expression
 and noIndentBreakNln astContext e ctx = 
     ifElse (checkPreserveBreakForExpr e ctx) (sepNln +> genExpr astContext e) (autoNln (genExpr astContext e)) ctx
@@ -285,10 +291,7 @@ and genLetBinding astContext pref b =
             +> ifElse isMutable (!- "mutable ") sepNone +> ifElse isInline (!- "inline ") sepNone
             +> genPat astContext p
 
-        match e with
-        | TypedExpr(Typed, e, t) -> prefix +> sepColon +> genType astContext false t +> sepEq
-                                    +> preserveBreakNlnOrAddSpace astContext e
-        | e -> prefix +> sepEq +> preserveBreakNlnOrAddSpace astContext e
+        genExprSepEqPrependType astContext prefix e
 
     | DoBinding(ats, px, e) ->
         let prefix = if pref.Contains("let") then pref.Replace("let", "do") else "do "
@@ -299,7 +302,7 @@ and genLetBinding astContext pref b =
         failwithf "%O isn't a let binding" b
 
 and genShortGetProperty astContext e = 
-    sepEq +> preserveBreakNlnOrAddSpace astContext e
+    genExprSepEqPrependType astContext !- "" e
 
 and genProperty astContext prefix ao propertyKind ps e =
     let tuplerize ps =
@@ -315,11 +318,11 @@ and genProperty astContext prefix ao propertyKind ps e =
         !- prefix +> opt sepSpace ao genAccess -- propertyKind
         +> ifElse (List.atMostOne ps) (col sepComma ps (genPat astContext) +> sepSpace) 
             (sepOpenT +> col sepComma ps (genPat astContext) +> sepCloseT +> sepSpace)
-        +> genPat astContext p +> sepEq +> preserveBreakNlnOrAddSpace astContext e
+        +> genPat astContext p +> genExprSepEqPrependType astContext !- "" e
 
     | ps -> 
         !- prefix +> opt sepSpace ao genAccess -- propertyKind +> col sepSpace ps (genPat astContext) 
-        +> sepEq +> preserveBreakNlnOrAddSpace astContext e
+        +> genExprSepEqPrependType astContext !- "" e
 
 and genPropertyWithGetSet astContext (b1, b2) =
     match b1, b2 with
@@ -333,7 +336,7 @@ and genPropertyWithGetSet astContext (b1, b2) =
         assert(ps2 |> Seq.map fst |> Seq.forall Option.isNone)
         let ps1 = List.map snd ps1
         let ps2 = List.map snd ps2
-        prefix -- s1 +> sepSpace +> indent +> sepNln
+        prefix -- s1 +> indent +> sepNln
         +> genProperty astContext "with " ao1 "get " ps1 e1 +> sepNln 
         +> genProperty astContext "and " ao2 "set " ps2 e2
         +> unindent
@@ -380,7 +383,7 @@ and genMemberBinding astContext b =
                 prefix -- s +> genShortGetProperty astContext e
             | _ ->
                 let ps = List.map snd ps              
-                prefix -- s +> sepSpace +> indent +> sepNln +> 
+                prefix -- s +> indent +> sepNln +> 
                 genProperty astContext "with " ao propertyKind ps e
                 +> unindent
         | p -> failwithf "Unexpected pattern: %O" p


### PR DESCRIPTION
Fix #225.

Refactor of "prepend type if expr is typed" pattern.

Remove spaces at end of line after `member`, and fix tests in that regard.