### PR TITLE
Fix 192

### DIFF
--- a/src/Fantomas.Tests/FunctionDefinitionTests.fs
+++ b/src/Fantomas.Tests/FunctionDefinitionTests.fs
@@ -267,8 +267,7 @@ let f = fun x -> match x with X (x) -> x
 """  config
     |> prepend newline
     |> should equal """
-type U =
-    | X of int
+type U = X of int
 
 let f =
     fun x -> 

--- a/src/Fantomas.Tests/RecordTests.fs
+++ b/src/Fantomas.Tests/RecordTests.fs
@@ -190,8 +190,7 @@ type rate2 = Rate of float<GBP/SGD*USD>
 type rate =
     { Rate : float<GBP * SGD / USD> }
 
-type rate2 =
-    | Rate of float<GBP / SGD * USD>
+type rate2 = Rate of float<GBP / SGD * USD>
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/TypeDeclarationTests.fs
+++ b/src/Fantomas.Tests/TypeDeclarationTests.fs
@@ -532,8 +532,7 @@ type Delegate3 = delegate of int -> (int -> int)
 
 type Delegate4 = delegate of int -> int -> int
 
-type U =
-    | U of (int * int)
+type U = U of (int * int)
 """
 
 [<Test>]

--- a/src/Fantomas.Tests/UnionTests.fs
+++ b/src/Fantomas.Tests/UnionTests.fs
@@ -126,8 +126,7 @@ let main argv =
    | _ -> 0""" config
     |> prepend newline
     |> should equal """
-type TestUnion =
-    | Test of A : int * B : int
+type TestUnion = Test of A : int * B : int
 
 [<EntryPoint>]
 let main argv =
@@ -154,4 +153,42 @@ type uColor =
 
 let col3 =
     Microsoft.FSharp.Core.LanguagePrimitives.EnumOfValue<uint32, uColor>(2u)
+"""
+
+[<Test>]
+let ``Single case DUs on same line`` () =
+    formatSourceString false """
+type CustomerId = 
+    | CustomerId of int
+    """ config
+    |> prepend newline
+    |> should equal """
+type CustomerId = CustomerId of int
+"""
+
+[<Test>]
+let ``Single case DU with private access modifier`` () =
+   formatSourceString false """
+type CustomerId =
+   private 
+   | CustomerId of int
+   """ config
+   |> prepend newline
+   |> should equal """
+type CustomerId = private CustomerId of int
+"""
+
+[<Test>]
+let ``Single case DU with member should be on a newline`` () =
+    formatSourceString false """
+type CustomerId =
+    | CustomerId of int
+    member this.Test() =
+        printfn "%A" this
+    """ config
+    |> prepend newline
+    |> should equal """
+type CustomerId =
+    | CustomerId of int
+    member this.Test() = printfn "%A" this
 """

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -8,7 +8,6 @@ open Fantomas
 open Fantomas.FormatConfig
 open Fantomas.SourceParser
 open Fantomas.SourceTransformer
-open Fantomas.SourceTransformer
 
 /// This type consists of contextual information which is important for formatting
 type ASTContext =

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -8,6 +8,7 @@ open Fantomas
 open Fantomas.FormatConfig
 open Fantomas.SourceParser
 open Fantomas.SourceTransformer
+open Fantomas.SourceTransformer
 
 /// This type consists of contextual information which is important for formatting
 type ASTContext =
@@ -690,9 +691,18 @@ and genTypeDefn astContext (TypeDef(ats, px, ao, tds, tcs, tdr, ms, s)) =
         +> unindent
 
     | Simple(TDSRUnion(ao', xs)) ->
+        let unionCases =  
+            match xs with
+            | [] -> id
+            | [x] when List.isEmpty ms -> 
+                indent +> sepSpace +> opt sepSpace ao' genAccess
+                +> genUnionCase { astContext with HasVerticalBar = false } x
+            | xs ->
+                indent +> sepNln +> opt sepNln ao' genAccess 
+                +> col sepNln xs (genUnionCase { astContext with HasVerticalBar = true })
+
         typeName +> sepEq 
-        +> indent +> sepNln +> opt sepNln ao' genAccess 
-        +> col sepNln xs (genUnionCase { astContext with HasVerticalBar = true })
+        +> unionCases
         +> genMemberDefnList { astContext with IsInterface = false } ms
         +> unindent
 


### PR DESCRIPTION
This would solve https://github.com/dungpa/fantomas/issues/192.
My mentor @AnthonyLloyd and I came up with this as part of the [F# Mentorship program](http://fsharp.org/mentorship/index.html).

There is currently no setting to indicate whether you want a single DU to be on one line or not.
And if the type has any members it will use a newline anyway.
Let us know if this requires further improvements.

We would be willing to resolve other issues as well. And perhaps try and migrate the project to a dotnet cli tool one day.