### PR TITLE
Hotfix for runtime issue when executing dotnet-fantomas

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -48,16 +48,16 @@
 
     <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
     <PropertyGroup>
-      <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketRestoreCacheFile) | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
-      <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketLockFilePath) | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+        <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketRestoreCacheFile) | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
+        <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketLockFilePath) | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
     </PropertyGroup>
 
     <!-- If shasum and awk exist get the hashes -->
     <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
-      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
+        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
     </Exec>
     <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
-      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
+        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
     </Exec>
 
     <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
@@ -127,7 +127,6 @@
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
         <PrivateAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'true'">All</PrivateAssets>
-        <ExcludeAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
       </PackageReference>
     </ItemGroup>
 
@@ -184,8 +183,8 @@
 
     <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
-    </ConvertToAbsolutePath>
-
+    </ConvertToAbsolutePath>      
+        
 
     <!-- Call Pack -->
     <PackTask Condition="$(UseNewPack)"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
-#### 2.7.0 - dd-MM-yyyy
+#### 2.7.1 - 03-05-2018
+* Hotfix for runtime problem when using dotnet cli tool
+
+#### 2.7.0 - 02-05-2018
 * Upgrade to .NET Core 2.0
 * Published as `clitool` 
 * Upgrade to FCS 22.0.3

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,5 +1,6 @@
 source https://www.nuget.org/api/v2/
 
+nuget FSharp.Core 4.3.4
 nuget FSharp.Compiler.Service 22.0.3
 nuget FsUnit 3.0.0
 nuget FsCheck

--- a/src/Fantomas.Cmd/AssemblyInfo.fs
+++ b/src/Fantomas.Cmd/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("Fantomas")>]
 [<assembly: AssemblyProductAttribute("Fantomas")>]
 [<assembly: AssemblyDescriptionAttribute("Source code formatter for F#")>]
-[<assembly: AssemblyVersionAttribute("2.7.0")>]
-[<assembly: AssemblyFileVersionAttribute("2.7.0")>]
+[<assembly: AssemblyVersionAttribute("2.7.1")>]
+[<assembly: AssemblyFileVersionAttribute("2.7.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "Fantomas"
     let [<Literal>] AssemblyProduct = "Fantomas"
     let [<Literal>] AssemblyDescription = "Source code formatter for F#"
-    let [<Literal>] AssemblyVersion = "2.7.0"
-    let [<Literal>] AssemblyFileVersion = "2.7.0"
+    let [<Literal>] AssemblyVersion = "2.7.1"
+    let [<Literal>] AssemblyFileVersion = "2.7.1"

--- a/src/Fantomas.Cmd/Fantomas.Cmd.fsproj
+++ b/src/Fantomas.Cmd/Fantomas.Cmd.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
-    <Version>2.7.0</Version>
+    <Version>2.7.1</Version>
     <AssemblyName>dotnet-fantomas</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas.Cmd/paket.references
+++ b/src/Fantomas.Cmd/paket.references
@@ -1,1 +1,2 @@
+FSharp.Core
 FSharp.Compiler.Service

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
-    <Version>2.7.0</Version>
+    <Version>2.7.1</Version>
     <NoWarn>FS0988</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fantomas/AssemblyInfo.fs
+++ b/src/Fantomas/AssemblyInfo.fs
@@ -7,8 +7,8 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyTitleAttribute("FantomasLib")>]
 [<assembly: AssemblyProductAttribute("Fantomas")>]
 [<assembly: AssemblyDescriptionAttribute("Source code formatter for F#")>]
-[<assembly: AssemblyVersionAttribute("2.7.0")>]
-[<assembly: AssemblyFileVersionAttribute("2.7.0")>]
+[<assembly: AssemblyVersionAttribute("2.7.1")>]
+[<assembly: AssemblyFileVersionAttribute("2.7.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -16,5 +16,5 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FantomasLib"
     let [<Literal>] AssemblyProduct = "Fantomas"
     let [<Literal>] AssemblyDescription = "Source code formatter for F#"
-    let [<Literal>] AssemblyVersion = "2.7.0"
-    let [<Literal>] AssemblyFileVersion = "2.7.0"
+    let [<Literal>] AssemblyVersion = "2.7.1"
+    let [<Literal>] AssemblyFileVersion = "2.7.1"

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
-    <Version>2.7.0</Version>
+    <Version>2.7.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="paket.references" />


### PR DESCRIPTION
https://www.nuget.org/packages/FSharp.Compiler.Service/ has a dependency on FSharp.Core higher or equal than 4.1.8, this caused for a mismatch in the generated `dotnet-fantomas.deps.json` located at `C:\Users\name\.nuget\packages\.tools\dotnet-fantomas\2.7.1\netcoreapp2.0`.

Long story short, the cli tool needs a direct dependency on FSharp.Core in order for this file to be generated correctly. I already pushed the fix to https://www.nuget.org/packages/dotnet-fantomas/2.7.1, it works now.